### PR TITLE
로그인 상태에 따른 헤더 데시보드 활성화여부&채권자 글읽기 페이지 오류 수정

### DIFF
--- a/my_precious_project/src/Components/Web/Web_Home_Components/HomeHeader.js
+++ b/my_precious_project/src/Components/Web/Web_Home_Components/HomeHeader.js
@@ -4,13 +4,18 @@ import styled, { ThemeProvider } from 'styled-components';
 import { useTheme } from '../../../contexts/ThemeContext.js'; // Context APi 적용
 import MGLogo from '../../../Assets/img/MGLogo.svg';
 import { useNavigate } from 'react-router-dom';
+import { useUserData } from "../../../contexts/userContext";
 
 const HomeHeader = () => {
     const theme = useTheme();
     const navigate = useNavigate();
+    const [userData, setUserData] = useUserData();
+    const uid = userData.uid;
 
     const navigateToDashboard = () => {
+        if(uid){
         navigate(`/dashboard/`);
+        }
     };
 
     const navigateToTeamNotion =(url) =>{
@@ -29,7 +34,7 @@ const HomeHeader = () => {
             </LogoBtn>
                 <NavRightSideDiv>
                     <AboutBtn onClick={()=>navigateToTeamNotion("https://dongwon0507.notion.site/2579c73b82614450ad676fe12f491ec9?pvs=4")}>ABOUT US</AboutBtn>
-                    <DashboardBtn>DASHBOARD</DashboardBtn>
+                    <DashboardBtn onClick={navigateToDashboard}>DASHBOARD</DashboardBtn>
                 </NavRightSideDiv>
             </Navigation>
         </ThemeProvider> 

--- a/my_precious_project/src/Components/Web/Web_RequestDetail_Components/CheckedMessage.js
+++ b/my_precious_project/src/Components/Web/Web_RequestDetail_Components/CheckedMessage.js
@@ -70,7 +70,7 @@ function CheckedMessage({ debtIdgnum }) {
 
   const CheckDebtStatusSubmit = (event) => {
     // 기본 양식 제출 동작 방지
-    event.preventDefault();
+    //event.preventDefault();
 
     setDetailData((detailData) => ({
       ...detailData,
@@ -123,6 +123,7 @@ function CheckedMessage({ debtIdgnum }) {
           <CheckBtn onClick={() => setModalShow(!modalShow)}>
             갚은 것을 확인했어요
           </CheckBtn>
+          <div id="modal"></div>
           {modalShow && (
             <Modal
               setModalShow={setModalShow}


### PR DESCRIPTION
1. 로그인/비로그인 상태에 따라 온보딩의 헤더 데시보드의 버튼을 활성화/비활성화하였습니다.
2. 채권자 글읽기 페이지에서 갚은 것을 확인했어요 버튼을 누를 때 뜨던 오류를 모달 컴퍼넌트를 추가한 부분 위에 <div>태그를 추가하고, 모달을 뜨고 확인버튼을 눌렀을 때 사용하는 함수 안에 있는 event.preventDefault(); 코드를 주석화하여 오류를 해결하였습니다.